### PR TITLE
Add support for ConnMan tech powered state updates.

### DIFF
--- a/src/nemo-connectivity/connectionhelper.cpp
+++ b/src/nemo-connectivity/connectionhelper.cpp
@@ -41,6 +41,7 @@
 #include <QtDBus/QDBusPendingCallWatcher>
 
 #include <connman-qt5/networkmanager.h>
+#include <connman-qt5/networktechnology.h>
 
 namespace Nemo {
 

--- a/src/nemo-connectivity/mobiledataconnection_p.h
+++ b/src/nemo-connectivity/mobiledataconnection_p.h
@@ -40,6 +40,7 @@
 
 #include <networkmanager.h>
 #include <networkservice.h>
+#include <networktechnology.h>
 
 #include <qofonoconnectioncontext.h>
 #include <qofononetworkregistration.h>
@@ -62,6 +63,9 @@ public:
     void updateNetworkServicePath();
     void updateSubscriberIdentity();
     void updateServiceProviderName();
+    void updateServiceAndTechnology();
+    void updateTechnology();
+    void techPoweredChanged(bool techPowered);
 
     QString servicePathForContext();
 
@@ -99,6 +103,7 @@ public:
 
     NetworkManager networkManager;
     NetworkService *networkService;
+    NetworkTechnology *networkTechnology;
     QOfonoNetworkRegistration networkRegistration;
 
     QSharedPointer<QOfonoConnectionManager> connectionManager;


### PR DESCRIPTION
Implement support for changing the powered state also in ConnMan when
the modem for to be used with cellular is selected. This is done using
the technology API of libconnman-qt and the purpose is to indicate the
proper powered state in ConnMan as well in order to get the value set in
the settings file so ConnMan does not disable mobile data when loading
the values.
