### PR TITLE
[nemo-connectivity] Remove all VPN Connect/Disconnect use. JB#62635

### DIFF
--- a/src/nemo-connectivity/settingsvpnmodel.cpp
+++ b/src/nemo-connectivity/settingsvpnmodel.cpp
@@ -241,16 +241,6 @@ void SettingsVpnModel::deleteConnection(const QString &path)
 
 }
 
-void SettingsVpnModel::activateConnection(const QString &path)
-{
-    vpnManager()->activateConnection(path);
-}
-
-void SettingsVpnModel::deactivateConnection(const QString &path)
-{
-    vpnManager()->deactivateConnection(path);
-}
-
 VpnConnection *SettingsVpnModel::get(int index) const
 {
     if (index >= 0 && index < connections().size()) {

--- a/src/nemo-connectivity/settingsvpnmodel.h
+++ b/src/nemo-connectivity/settingsvpnmodel.h
@@ -70,9 +70,6 @@ public:
     Q_INVOKABLE void modifyConnection(const QString &path, const QVariantMap &properties);
     Q_INVOKABLE void deleteConnection(const QString &path);
 
-    Q_INVOKABLE void activateConnection(const QString &path);
-    Q_INVOKABLE void deactivateConnection(const QString &path);
-
     Q_INVOKABLE QVariantMap connectionCredentials(const QString &path);
     Q_INVOKABLE void setConnectionCredentials(const QString &path, const QVariantMap &credentials);
 

--- a/src/plugin/plugins.qmltypes
+++ b/src/plugin/plugins.qmltypes
@@ -106,14 +106,6 @@ Module {
             Parameter { name: "path"; type: "string" }
         }
         Method {
-            name: "activateConnection"
-            Parameter { name: "path"; type: "string" }
-        }
-        Method {
-            name: "deactivateConnection"
-            Parameter { name: "path"; type: "string" }
-        }
-        Method {
             name: "connectionCredentials"
             type: "QVariantMap"
             Parameter { name: "path"; type: "string" }


### PR DESCRIPTION
The autoconnect value handles disconnects for VPNs. No need to have Connect()/Disconnect() use here, since the D-Bus API use on this part is blocked from anything external.