### PR TITLE
Add Unknown connectivity state

### DIFF
--- a/src/nemo-connectivity/connectionhelper.cpp
+++ b/src/nemo-connectivity/connectionhelper.cpp
@@ -79,7 +79,7 @@ ConnectionHelperPrivate::ConnectionHelperPrivate()
     , m_detectingNetworkConnection(false)
     , m_connmanIsAvailable(false)
     , m_selectorVisible(false)
-    , m_status(Nemo::ConnectionHelper::Offline)
+    , m_status(Nemo::ConnectionHelper::Unknown)
     , m_netman(NetworkManager::sharedInstance())
     , m_connectionSelectorInterface(nullptr)
 {

--- a/src/nemo-connectivity/connectionhelper.h
+++ b/src/nemo-connectivity/connectionhelper.h
@@ -71,6 +71,7 @@ public:
     bool online() const;
 
     enum Status {
+        Unknown = -1,
         Offline = 0,
         Connecting,
         Connected,

--- a/src/nemo-connectivity/settingsvpnmodel.cpp
+++ b/src/nemo-connectivity/settingsvpnmodel.cpp
@@ -36,10 +36,11 @@
 #include <QCryptographicHash>
 #include <QQmlEngine>
 #include <QDir>
-#include <QXmlQuery>
-#include <QXmlResultItems>
 #include <QSettings>
 #include <QLoggingCategory>
+
+#include <QXmlQuery>
+#include <QXmlResultItems>
 
 #include "vpnmanager.h"
 
@@ -214,7 +215,7 @@ void SettingsVpnModel::deleteConnection(const QString &path)
             fileProperties << QStringLiteral("OpenVPN.Cert") << QStringLiteral("OpenVPN.Key")
                            << QStringLiteral("OpenVPN.CACert") << QStringLiteral("OpenVPN.ConfigFile");
 
-            for (const QString property : fileProperties) {
+            for (const QString &property : fileProperties) {
                 const QString filename = providerProperties.value(property).toString();
 
                 // Check if the file has been provisioned
@@ -257,7 +258,7 @@ VpnConnection *SettingsVpnModel::get(int index) const
         return item;
     }
 
-    return 0;
+    return nullptr;
 
 }
 

--- a/src/plugin/plugins.qmltypes
+++ b/src/plugin/plugins.qmltypes
@@ -16,6 +16,7 @@ Module {
         Enum {
             name: "Status"
             values: {
+                "Unknown": -1,
                 "Offline": 0,
                 "Connecting": 1,
                 "Connected": 2,


### PR DESCRIPTION
Main commit:

    On instantiation it's not immediately known whether the device is
    online or offline. Earlier the component was saying offline.
    Let's be honest about the unknown state and let apps handle it.
    
    -1 now matching MobileDataConnection::Unknown.

Got into this by checking why sailfish-weather does some warnings on startup. Not yet sure should exactly this be used there on request side logic but thinking this makes sense to add on its own.