### PR TITLE
Adding some example vpn setup files to ease testing

### DIFF
--- a/example_data/anyconnect.xml
+++ b/example_data/anyconnect.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnyConnectProfile xmlns="http://schemas.xmlsoap.org/encoding/"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=
+ "http://schemas.xmlsoap.org/encoding/ AnyConnectProfile.xsd">
+   <ClientInitialization>
+    <UseStartBeforeLogon UserControllable="true">false</UseStartBeforeLogon>
+    <AutomaticCertSelection UserControllable="true">false
+      </AutomaticCertSelection>
+    <ShowPreConnectMessage>false</ShowPreConnectMessage>
+    <CertificateStore>All</CertificateStore>
+    <CertificateStoreOverride>false</CertificateStoreOverride>
+    <ProxySettings>Native</ProxySettings>
+    <AllowLocalProxyConnections>true</AllowLocalProxyConnections>
+    <AuthenticationTimeout>12</AuthenticationTimeout>
+    <AutoConnectOnStart UserControllable="true">false</AutoConnectOnStart>
+    <MinimizeOnConnect UserControllable="true">true</MinimizeOnConnect>
+    <LocalLanAccess UserControllable="true">false</LocalLanAccess>
+    <ClearSmartcardPin UserControllable="true">true</ClearSmartcardPin>
+    <AutoReconnect UserControllable="false">true
+       <AutoReconnectBehavior UserControllable="false">DisconnectOnSuspend 
+        </AutoReconnectBehavior>
+    </AutoReconnect>
+    <AutoUpdate UserControllable="false">true</AutoUpdate>
+    <RSASecurIDIntegration UserControllable="true">Automatic
+      </RSASecurIDIntegration>
+    <WindowsLogonEnforcement>SingleLocalLogon</WindowsLogonEnforcement>
+    <WindowsVPNEstablishment>LocalUsersOnly</WindowsVPNEstablishment>
+    <AutomaticVPNPolicy>false</AutomaticVPNPolicy>
+    <PPPExclusion UserControllable="false">Disable
+       <PPPExclusionServerIP UserControllable="false"></PPPExclusionServerIP>
+    </PPPExclusion>
+    <EnableScripting UserControllable="false">false</EnableScripting>
+    <EnableAutomaticServerSelection UserControllable="false">false
+       <AutoServerSelectionImprovement>20</AutoServerSelectionImprovement>
+       <AutoServerSelectionSuspendTime>4</AutoServerSelectionSuspendTime>
+    </EnableAutomaticServerSelection>
+    <RetainVpnOnLogoff>false
+    </RetainVpnOnLogoff>
+  </ClientInitialization>
+  <ServerList>
+      <HostEntry>
+          <HostName>bsns-asa5520-1</HostName>
+          <HostAddress>bsns-asa5520-1.cisco.com</HostAddress>
+          <UserGroup>AC</UserGroup>
+      <PrimaryProtocol>IPsec</PrimaryProtocol>
+      </HostEntry>
+  </ServerList>
+</AnyConnectProfile>

--- a/example_data/cisco.xml
+++ b/example_data/cisco.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnyConnectProfile xmlns="http://schemas.xmlsoap.org/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.xmlsoap.org/encoding/ AnyConnectProfile.xsd">
+<ClientInitialization>
+<UseStartBeforeLogon UserControllable="true">true</UseStartBeforeLogon>
+<AutomaticCertSelection UserControllable="false">true</AutomaticCertSelection>
+<ShowPreConnectMessage>false</ShowPreConnectMessage>
+<CertificateStore>All</CertificateStore>
+<CertificateStoreMac>All</CertificateStoreMac>
+<CertificateStoreLinux>All</CertificateStoreLinux>
+<CertificateStoreOverride>false</CertificateStoreOverride>
+<ProxySettings>Native</ProxySettings>
+<AllowLocalProxyConnections>true</AllowLocalProxyConnections>
+<AuthenticationTimeout>30</AuthenticationTimeout>
+<AutoConnectOnStart UserControllable="true">false</AutoConnectOnStart>
+<MinimizeOnConnect UserControllable="true">true</MinimizeOnConnect>
+<LocalLanAccess UserControllable="true">false</LocalLanAccess>
+<DisableCaptivePortalDetection UserControllable="true">false</DisableCaptivePortalDetection>
+<ClearSmartcardPin UserControllable="false">true</ClearSmartcardPin>
+<IPProtocolSupport>IPv4,IPv6</IPProtocolSupport>
+<AutoReconnect UserControllable="false">true
+<AutoReconnectBehavior UserControllable="false">ReconnectAfterResume</AutoReconnectBehavior>
+</AutoReconnect>
+<SuspendOnConnectedStandby>false</SuspendOnConnectedStandby>
+<AutoUpdate UserControllable="false">true</AutoUpdate>
+<RSASecurIDIntegration UserControllable="false">Automatic</RSASecurIDIntegration>
+<WindowsLogonEnforcement>SingleLocalLogon</WindowsLogonEnforcement>
+<LinuxLogonEnforcement>SingleLocalLogon</LinuxLogonEnforcement>
+<WindowsVPNEstablishment>LocalUsersOnly</WindowsVPNEstablishment>
+<LinuxVPNEstablishment>LocalUsersOnly</LinuxVPNEstablishment>
+<AutomaticVPNPolicy>false</AutomaticVPNPolicy>
+<PPPExclusion UserControllable="false">Disable
+<PPPExclusionServerIP UserControllable="false"></PPPExclusionServerIP>
+</PPPExclusion>
+<EnableScripting UserControllable="false">false</EnableScripting>
+<EnableAutomaticServerSelection UserControllable="false">false
+<AutoServerSelectionImprovement>20</AutoServerSelectionImprovement>
+<AutoServerSelectionSuspendTime>4</AutoServerSelectionSuspendTime>
+</EnableAutomaticServerSelection>
+<RetainVpnOnLogoff>false
+</RetainVpnOnLogoff>
+<CaptivePortalRemediationBrowserFailover>false</CaptivePortalRemediationBrowserFailover>
+<AllowManualHostInput>true</AllowManualHostInput>
+</ClientInitialization>
+<ServerList>
+<HostEntry>
+<HostName>Corp VPN</HostName>
+<HostAddress>vpn.domain.com</HostAddress>
+<UserGroup>TUNNELNAME</UserGroup>
+</HostEntry>
+</ServerList>
+</AnyConnectProfile>

--- a/example_data/fortinet.conf
+++ b/example_data/fortinet.conf
@@ -1,0 +1,58 @@
+<forticlient_configuration>
+	<vpn>
+		<sslvpn>
+			<options>
+				<enabled>1</enabled>
+				<dnscache_service_control>0</dnscache_service_control>
+				<!-- 0=disable dnscache, 1=do not tounch dnscache service, 2=restart dnscache service, 3=sc control dnscache paramchange -->
+				<prefer_sslvpn_dns>1</prefer_sslvpn_dns>
+				<use_legacy_ssl_adapter>1</use_legacy_ssl_adapter>
+				<preferred_dtls_tunnel>1</preferred_dtls_tunnel>
+				<block_ipv6>0</block_ipv6>
+				<no_dhcp_server_route>0</no_dhcp_server_route>
+				<no_dns_registration>0</no_dns_registration>
+				<disallow_invalid_server_certificate>0</disallow_invalid_server_certificate>
+				<keep_connection_alive>1</keep_connection_alive>
+			</options>
+			<connections>
+				<connection>
+					<name>SSLVPN_TEST</name>
+					<description>TEST config</description>
+					<server>ssldemo.fortinet.com:10443</server>
+					<username>Username</username>
+					<single_user_mode>0</single_user_mode>
+					<disclaimer_msg></disclaimer_msg>
+					<ui>
+						<show_remember_password>1</show_remember_password>
+						<show_alwaysup>1</show_alwaysup>
+						<show_autoconnect>1</show_autoconnect>
+						<save_username>0</save_username>
+					</ui>
+					<!-- password>Encrypted/NonEncrypted_PasswordString</password -->
+					<certificate />
+					<warn_invalid_server_certificate>1</warn_invalid_server_certificate>
+					<allow_standard_user_use_system_cert>0</allow_standard_user_use_system_cert>
+					<prompt_certificate>0</prompt_certificate>
+					<prompt_username>1</prompt_username>
+					<fgt>1</fgt>
+					<on_connect>
+						<script>
+						<os>windows</os>
+							<script>
+								<![CDATA[test]]>
+							</script>
+						</script>
+					</on_connect>
+					<on_disconnect>
+					<script>
+						<os>windows</os>
+						<script>
+							<![CDATA[]]>
+						</script>
+					</script>
+					</on_disconnect>
+				</connection>
+			</connections>
+		</sslvpn>
+	</vpn>
+</forticlient_configuration>


### PR DESCRIPTION
Files from Jussi Laakkonen. Helps a bit testing the vpn config parsing when not needing to dig the internet for files to test.

Ideally these could be used for unit test for the vpn config parsing but the whole test setup would need to be implemented. Left for later excercise.

---

These taken out from discussion on #8 